### PR TITLE
Use device index in number entity

### DIFF
--- a/custom_components/poolsync/number.py
+++ b/custom_components/poolsync/number.py
@@ -58,7 +58,7 @@ class PoolSyncChlorOutputNumber(CoordinatorEntity[PoolSyncCoordinator], NumberEn
     @property
     def native_value(self) -> float | None:
         data = self.coordinator.data or {}
-        val = _g(data, "devices", "0", "config", "chlorOutput")
+        val = _g(data, "devices", str(self._device_index), "config", "chlorOutput")
         try:
             return float(val)
         except Exception:


### PR DESCRIPTION
## Summary
- Use the configured device index to access chlor output in number entity

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f3abe7968832eaa12747e5f85ba45