### PR TITLE
Handle push-link failure

### DIFF
--- a/custom_components/poolsync/config_flow.py
+++ b/custom_components/poolsync/config_flow.py
@@ -68,7 +68,7 @@ class PoolSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
         if not ok or not token:
             _LOGGER.debug("Link mode failed: %s", err or "unknown error")
-            return self.async_abort(reason="cannot_connect")
+            return self.async_abort(reason="pushlink_failed")
 
         # Create the entry and persist the token + the SAME ephemeral user used
         title = f"PoolSync ({mac})" if mac else "PoolSync"


### PR DESCRIPTION
## Summary
- handle push-link exchange failure with specific `pushlink_failed` abort reason

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f3b1d8488832e80e8c552338cc8c4