### PR TITLE
Use device index when reading boost state

### DIFF
--- a/custom_components/poolsync/switch.py
+++ b/custom_components/poolsync/switch.py
@@ -54,7 +54,14 @@ class PoolSyncBoostSwitch(CoordinatorEntity[PoolSyncCoordinator], SwitchEntity):
     def is_on(self) -> bool:
         data = self.coordinator.data or {}
         # No explicit boolean in sample JSON; infer from boostRemaining minutes > 0
-        remaining = _g(data, "devices", "0", "status", "boostRemaining", default=0)
+        remaining = _g(
+            data,
+            "devices",
+            str(self._device_index),
+            "status",
+            "boostRemaining",
+            default=0,
+        )
         try:
             return int(remaining) > 0
         except Exception:


### PR DESCRIPTION
## Summary
- use device index when retrieving boostRemaining for switch state

## Testing
- `python -m py_compile custom_components/poolsync/switch.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f3cab3ccc832ea7a4745341bd91ed