### PR TITLE
Replace deprecated get_event_loop usage

### DIFF
--- a/custom_components/poolsync/api.py
+++ b/custom_components/poolsync/api.py
@@ -186,7 +186,7 @@ class PoolSyncApi:
             return False, None, None, used_user, f"pushLink start failed: status={st}, body={text}"
 
         # 2) Poll
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
         poll = 0
 


### PR DESCRIPTION
## Summary
- use asyncio.get_running_loop in push-link exchange

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f458b75c0832e955b71b0e16fac97