### PR TITLE
Add os import to test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+from dataclasses import dataclass
 
 # Ensure repository root on path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -64,8 +65,6 @@ class Dummy:
 
 class SensorEntity:
     pass
-
-from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class SensorEntityDescription:


### PR DESCRIPTION
## Summary
- Import `os` alongside other top-level imports in test fixtures
- Move dataclasses import to the top of `tests/conftest.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f458f7ac0832e84debe8f7c090378