### PR TITLE
refactor: share nested lookup helper

### DIFF
--- a/custom_components/poolsync/number.py
+++ b/custom_components/poolsync/number.py
@@ -10,15 +10,7 @@ from homeassistant.const import PERCENTAGE
 
 from .const import DOMAIN
 from .coordinator import PoolSyncCoordinator
-
-
-def _g(d: dict, *path, default=None):
-    cur: Any = d
-    for p in path:
-        if not isinstance(cur, dict) or p not in cur:
-            return default
-        cur = cur[p]
-    return cur
+from .util import _g
 
 
 async def async_setup_entry(

--- a/custom_components/poolsync/sensor.py
+++ b/custom_components/poolsync/sensor.py
@@ -23,6 +23,7 @@ from homeassistant.config_entries import ConfigEntry
 
 from .coordinator import PoolSyncCoordinator
 from .const import DOMAIN
+from .util import _g
 
 
 @dataclass(frozen=True)
@@ -30,27 +31,6 @@ class PoolSyncSensorDesc(SensorEntityDescription):
     """Extend SensorEntityDescription with a value extractor."""
     value_fn: Callable[[dict[str, Any]], Any] | None = None
     attr_fn: Callable[[dict[str, Any]], dict[str, Any]] | None = None
-
-
-def _g(d: dict, *path, default=None):
-    cur: Any = d
-    for p in path:
-        if isinstance(cur, dict):
-            if p not in cur:
-                return default
-            cur = cur[p]
-            continue
-        if isinstance(cur, list):
-            try:
-                idx = int(p)
-            except (TypeError, ValueError):
-                return default
-            if idx < 0 or idx >= len(cur):
-                return default
-            cur = cur[idx]
-            continue
-        return default
-    return cur
 
 
 def _dev0(data: dict) -> dict:

--- a/custom_components/poolsync/switch.py
+++ b/custom_components/poolsync/switch.py
@@ -9,15 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 
 from .const import DOMAIN
 from .coordinator import PoolSyncCoordinator
-
-
-def _g(d: dict, *path, default=None):
-    cur: Any = d
-    for p in path:
-        if not isinstance(cur, dict) or p not in cur:
-            return default
-        cur = cur[p]
-    return cur
+from .util import _g
 
 
 async def async_setup_entry(

--- a/custom_components/poolsync/util.py
+++ b/custom_components/poolsync/util.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _g(d: dict, *path, default=None):
+    cur: Any = d
+    for p in path:
+        if isinstance(cur, dict):
+            if p not in cur:
+                return default
+            cur = cur[p]
+            continue
+        if isinstance(cur, list):
+            try:
+                idx = int(p)
+            except (TypeError, ValueError):
+                return default
+            if idx < 0 or idx >= len(cur):
+                return default
+            cur = cur[idx]
+            continue
+        return default
+    return cur


### PR DESCRIPTION
## Summary
- add util._g for nested dict/list traversal
- use shared `_g` in sensor, switch, and number

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f458ea9d8832ea6d12e23f20048eb