### PR TITLE
Add heat pump support to PoolSync integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Local-polling integration for the PoolSync bridge.
 - Sensors: Water Temp, Board Temp, Flow Rate, Salt PPM, Chlor Output, Boost Remaining, RSSI, Volume, Polarity Change, Cell Rail Voltage, Cell Raw Salt ADC, Online
 - Number: Chlor Output (0–100%)
 - Switch: Salt Boost (24h) via `boostMode`
+- Experimental heat pump support (sensors and setpoint/mode control)
 
 ### Push-link onboarding
 

--- a/custom_components/poolsync/__init__.py
+++ b/custom_components/poolsync/__init__.py
@@ -23,7 +23,7 @@ from .coordinator import PoolSyncCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = ["sensor", "switch", "number"]
+PLATFORMS: list[str] = ["sensor", "switch", "number", "binary_sensor"]
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True

--- a/custom_components/poolsync/api.py
+++ b/custom_components/poolsync/api.py
@@ -126,6 +126,14 @@ class PoolSyncApi:
         """PATCH /api/poolsync?cmd=devices&device=<index> with {'boostMode': bool}."""
         return await self._patch_devices(device_index, {"boostMode": bool(on)})
 
+    async def set_heatpump_setpoint(self, device_index: int, value: float) -> Dict[str, Any]:
+        """PATCH device setpoint for heat pump."""
+        return await self._patch_devices(device_index, {"setpoint": value})
+
+    async def set_heatpump_mode(self, device_index: int, mode: int) -> Dict[str, Any]:
+        """PATCH device mode for heat pump."""
+        return await self._patch_devices(device_index, {"mode": int(mode)})
+
     async def _patch_devices(self, device_index: int, payload: Dict[str, Any]) -> Dict[str, Any]:
         headers = {"Content-Type": "application/json"}
         status, text, data = await self._request_json(

--- a/custom_components/poolsync/binary_sensor.py
+++ b/custom_components/poolsync/binary_sensor.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import PoolSyncCoordinator
+from .util import _g
+
+
+@dataclass(frozen=True)
+class PoolSyncBinarySensorDesc(BinarySensorEntityDescription):
+    """Descriptor with a value extractor."""
+
+    value_fn: Callable[[dict[str, Any]], Any] | None = None
+
+
+class PoolSyncBinarySensor(CoordinatorEntity[PoolSyncCoordinator], BinarySensorEntity):
+    """Generic PoolSync binary sensor."""
+
+    entity_description: PoolSyncBinarySensorDesc
+
+    def __init__(
+        self,
+        coordinator: PoolSyncCoordinator,
+        entry: ConfigEntry,
+        description: PoolSyncBinarySensorDesc,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+
+        mac = coordinator.api.mac_address or entry.data.get("mac") or "poolsync"
+        self._attr_unique_id = f"{mac}_{description.key}"
+        self._attr_has_entity_name = True
+        self._attr_name = description.name
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, mac)},
+            "manufacturer": "AquaCal",
+            "name": "PoolSync",
+            "model": "PoolSync",
+        }
+
+    @property
+    def is_on(self) -> Optional[bool]:
+        data = self.coordinator.data or {}
+        if self.entity_description.value_fn is None:
+            return None
+        try:
+            val = self.entity_description.value_fn(data)
+        except Exception:
+            return None
+        if val is None:
+            return None
+        if isinstance(val, bool):
+            return val
+        if isinstance(val, int):
+            return val != 0
+        return bool(val)
+
+    @property
+    def available(self) -> bool:
+        return self.is_on is not None
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    coordinator: PoolSyncCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+
+    entities: list[PoolSyncBinarySensor] = []
+
+    data = coordinator.data or {}
+    device_types = _g(data, "deviceType", default={}) or {}
+    heatpump_idx = next(
+        (idx for idx, dev in device_types.items() if dev == "heatPump"),
+        None,
+    )
+
+    if heatpump_idx is not None:
+        hp_idx = str(heatpump_idx)
+        sensors = [
+            PoolSyncBinarySensorDesc(
+                key="heatpump_online",
+                name="Heat Pump Online",
+                device_class=BinarySensorDeviceClass.CONNECTIVITY,
+                value_fn=lambda d, i=hp_idx: _g(d, "devices", i, "nodeAttr", "online"),
+            ),
+            PoolSyncBinarySensorDesc(
+                key="heatpump_fault",
+                name="Heat Pump Fault",
+                device_class=BinarySensorDeviceClass.PROBLEM,
+                value_fn=lambda d, i=hp_idx: (
+                    any(f != 0 for f in (_g(d, "devices", i, "faults") or []))
+                ),
+            ),
+            PoolSyncBinarySensorDesc(
+                key="heatpump_flow",
+                name="Heat Pump Flow",
+                value_fn=lambda d, i=hp_idx: (
+                    (_g(d, "devices", i, "status", "ctrlFlags") or 0) >= 1
+                ),
+            ),
+            PoolSyncBinarySensorDesc(
+                key="heatpump_compressor",
+                name="Heat Pump Compressor",
+                value_fn=lambda d, i=hp_idx: (
+                    (_g(d, "devices", i, "status", "stateFlags") or 0) == 8
+                ),
+            ),
+            PoolSyncBinarySensorDesc(
+                key="heatpump_fan",
+                name="Heat Pump Fan",
+                value_fn=lambda d, i=hp_idx: (
+                    (_g(d, "devices", i, "status", "stateFlags") or 0) in (8, 520)
+                ),
+            ),
+        ]
+        for desc in sensors:
+            entities.append(PoolSyncBinarySensor(coordinator, entry, desc))
+
+    if entities:
+        async_add_entities(entities, update_before_add=True)

--- a/custom_components/poolsync/number.py
+++ b/custom_components/poolsync/number.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
 
 from .const import DOMAIN
 from .coordinator import PoolSyncCoordinator
@@ -21,6 +19,23 @@ async def async_setup_entry(
     entities: list[NumberEntity] = [
         PoolSyncChlorOutputNumber(coordinator, entry, device_index=0),
     ]
+
+    data = coordinator.data or {}
+    device_types = _g(data, "deviceType", default={}) or {}
+    heatpump_idx = next(
+        (idx for idx, dev in device_types.items() if dev == "heatPump"),
+        None,
+    )
+
+    if heatpump_idx is not None:
+        hp_idx = int(heatpump_idx)
+        entities.extend(
+            [
+                PoolSyncHeatSetpointNumber(coordinator, entry, device_index=hp_idx),
+                PoolSyncHeatModeNumber(coordinator, entry, device_index=hp_idx),
+            ]
+        )
+
     async_add_entities(entities, update_before_add=True)
 
 
@@ -62,5 +77,92 @@ class PoolSyncChlorOutputNumber(CoordinatorEntity[PoolSyncCoordinator], NumberEn
         # Clamp/round to int 0..100 for API
         pct = max(0, min(100, int(round(value))))
         await self.coordinator.api.set_chlor_output(self._device_index, pct)
+        await self.coordinator.async_request_refresh()
+
+
+class PoolSyncHeatSetpointNumber(CoordinatorEntity[PoolSyncCoordinator], NumberEntity):
+    """Number for heat pump temperature setpoint."""
+
+    _attr_mode = NumberMode.SLIDER
+
+    def __init__(
+        self, coordinator: PoolSyncCoordinator, entry: ConfigEntry, device_index: int
+    ) -> None:
+        super().__init__(coordinator)
+        self._device_index = device_index
+        mac = coordinator.api.mac_address or entry.data.get("mac") or "poolsync"
+        self._attr_unique_id = f"{mac}_heat_setpoint_{device_index}"
+        self._attr_name = "Heat Pump Setpoint"
+
+        unit = coordinator.hass.config.units.temperature_unit
+        if unit == UnitOfTemperature.FAHRENHEIT:
+            self._attr_native_unit_of_measurement = UnitOfTemperature.FAHRENHEIT
+            self._attr_min_value = 40
+            self._attr_max_value = 104
+            self._attr_step = 1
+            self._attr_mode = NumberMode.BOX
+        else:
+            self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+            self._attr_min_value = 5
+            self._attr_max_value = 40
+            self._attr_step = 0.5
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, mac)},
+            "manufacturer": "AquaCal",
+            "name": "PoolSync",
+            "model": "PoolSync",
+        }
+
+    @property
+    def native_value(self) -> float | None:
+        data = self.coordinator.data or {}
+        val = _g(data, "devices", str(self._device_index), "config", "setpoint")
+        try:
+            return float(val)
+        except Exception:
+            return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self.coordinator.api.set_heatpump_setpoint(self._device_index, value)
+        await self.coordinator.async_request_refresh()
+
+
+class PoolSyncHeatModeNumber(CoordinatorEntity[PoolSyncCoordinator], NumberEntity):
+    """Number for heat pump mode selection."""
+
+    _attr_min_value = 0
+    _attr_max_value = 2
+    _attr_step = 1
+    _attr_mode = NumberMode.BOX
+
+    def __init__(
+        self, coordinator: PoolSyncCoordinator, entry: ConfigEntry, device_index: int
+    ) -> None:
+        super().__init__(coordinator)
+        self._device_index = device_index
+        mac = coordinator.api.mac_address or entry.data.get("mac") or "poolsync"
+        self._attr_unique_id = f"{mac}_heat_mode_{device_index}"
+        self._attr_name = "Heat Pump Mode"
+
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, mac)},
+            "manufacturer": "AquaCal",
+            "name": "PoolSync",
+            "model": "PoolSync",
+        }
+
+    @property
+    def native_value(self) -> float | None:
+        data = self.coordinator.data or {}
+        val = _g(data, "devices", str(self._device_index), "config", "mode")
+        try:
+            return float(val)
+        except Exception:
+            return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        mode = int(value)
+        await self.coordinator.api.set_heatpump_mode(self._device_index, mode)
         await self.coordinator.async_request_refresh()
 


### PR DESCRIPTION
## Summary
- add binary_sensor platform and heat pump sensors
- expose heat pump setpoint and mode numbers
- support heat pump control API methods
- document experimental heat pump support in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f5904f2a0832e9ec6907f4d3c21f1