### PR TITLE
Add ping button for immediate PoolSync update

### DIFF
--- a/custom_components/poolsync/__init__.py
+++ b/custom_components/poolsync/__init__.py
@@ -23,7 +23,14 @@ from .coordinator import PoolSyncCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = ["sensor", "switch", "number", "binary_sensor", "climate"]
+PLATFORMS: list[str] = [
+    "sensor",
+    "switch",
+    "number",
+    "binary_sensor",
+    "climate",
+    "button",
+]
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True

--- a/custom_components/poolsync/button.py
+++ b/custom_components/poolsync/button.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import PoolSyncCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the PoolSync Ping button."""
+    coordinator: PoolSyncCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    async_add_entities([PoolSyncPingButton(coordinator, entry)])
+
+
+class PoolSyncPingButton(CoordinatorEntity[PoolSyncCoordinator], ButtonEntity):
+    """Button to trigger an immediate PoolSync data refresh."""
+
+    def __init__(self, coordinator: PoolSyncCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        mac = coordinator.api.mac_address or entry.data.get("mac") or "poolsync"
+        self._attr_unique_id = f"{mac}_ping"
+        self._attr_name = "Ping"
+        self._attr_icon = "mdi:lan-connect"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, mac)},
+            "manufacturer": "AquaCal",
+            "name": "PoolSync",
+            "model": "PoolSync",
+        }
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        await self.coordinator.async_request_refresh()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,9 @@ sys.modules["homeassistant.components.sensor"] = sensor_mod
 sensor_const_mod = types.ModuleType("homeassistant.components.sensor.const")
 sys.modules["homeassistant.components.sensor.const"] = sensor_const_mod
 
+button_mod = types.ModuleType("homeassistant.components.button")
+sys.modules["homeassistant.components.button"] = button_mod
+
 helpers_mod = types.ModuleType("homeassistant.helpers")
 sys.modules["homeassistant.helpers"] = helpers_mod
 
@@ -76,6 +79,11 @@ class SensorEntityDescription:
 sensor_mod.SensorEntity = SensorEntity
 sensor_mod.SensorEntityDescription = SensorEntityDescription
 
+class ButtonEntity:
+    pass
+
+button_mod.ButtonEntity = ButtonEntity
+
 class SensorDeviceClass:
     TEMPERATURE = "temperature"
     SIGNAL_STRENGTH = "signal_strength"
@@ -85,6 +93,9 @@ class SensorDeviceClass:
 
 sensor_const_mod.SensorDeviceClass = SensorDeviceClass
 class CoordinatorEntity:
+    def __init__(self, coordinator=None):
+        self.coordinator = coordinator
+
     @classmethod
     def __class_getitem__(cls, item):
         return cls

--- a/tests/test_ping_button.py
+++ b/tests/test_ping_button.py
@@ -1,0 +1,24 @@
+import asyncio
+
+from custom_components.poolsync.button import PoolSyncPingButton
+
+
+class DummyCoordinator:
+    def __init__(self):
+        self.api = type("api", (), {"mac_address": "00:11"})()
+        self.refresh_called = False
+
+    async def async_request_refresh(self):
+        self.refresh_called = True
+
+
+class DummyEntry:
+    data: dict = {}
+
+
+def test_ping_button_requests_refresh():
+    coordinator = DummyCoordinator()
+    entry = DummyEntry()
+    button = PoolSyncPingButton(coordinator, entry)
+    asyncio.run(button.async_press())
+    assert coordinator.refresh_called


### PR DESCRIPTION
## Summary
- add Ping button entity to trigger on-demand PoolSync data refresh
- register button platform
- test button forces immediate coordinator refresh

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a524cfa858832e8e9aee210cd9a37e